### PR TITLE
Add klint gradle plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,4 @@
 [*.{kt,kts}]
 indent_size=4
-continuation_indent_size=4
 insert_final_newline=true
 max_line_length=120

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,4 +3,3 @@ indent_size=4
 continuation_indent_size=4
 insert_final_newline=true
 max_line_length=120
-

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.{kt,kts}]
+indent_size=4
+continuation_indent_size=4
+insert_final_newline=true
+max_line_length=120
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,3 @@
-[*.{kt,kts}]
-indent_size=4
+[*.{kt,kts}] indent_size=4
 insert_final_newline=true
-max_line_length=120
+max_line_length=100

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
-[*.{kt,kts}] indent_size=4
+[*.{kt,kts}]
+indent_size=4
 insert_final_newline=true
 max_line_length=100

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ cache:
 
 install:
   - "./gradlew assemble"
+  - 'git diff --exit-code'
 
 script:
   - "./gradlew test jacocoTestReport"

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ subprojects {
 
     // Optionally configure plugin
     ktlint {
+        version = "0.31.0"
         debug = true
         android = true
         ignoreFailures = true

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ subprojects {
     // Optionally configure plugin
     ktlint {
         version = "0.31.0"
+        enableExperimentalRules = true
         debug = true
         android = true
         ignoreFailures = true

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-
     ext.jacocoVersion = '0.8.2'
     ext.kotlinVersion = '1.3.21'
 
     repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
         mavenLocal()
         mavenCentral()
         google()
         jcenter()
-        
+
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
@@ -18,6 +20,7 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jacoco:org.jacoco.core:$jacocoVersion"
         classpath 'net.researchgate:gradle-release:2.8.0'
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:7.3.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -30,10 +33,26 @@ allprojects {
         mavenCentral()
         google()
         jcenter()
-        
+
+    }
+    tasks.whenTaskAdded { theTask ->
+        if (theTask.name.equals('assemble')) {
+            theTask.dependsOn ktlintFormat
+        }
     }
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+subprojects {
+    apply plugin: "org.jlleitschuh.gradle.ktlint" // Version should be inherited from parent
+
+    // Optionally configure plugin
+    ktlint {
+        debug = true
+        android = true
+        ignoreFailures = true
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
 
     }
     tasks.whenTaskAdded { theTask ->
-        if (theTask.name.equals('assemble')) {
+        if (theTask.name.startsWith('compile')) {
             theTask.dependsOn ktlintFormat
         }
     }

--- a/velocidi-sdk/src/main/kotlin/com/velocidi/Velocidi.kt
+++ b/velocidi-sdk/src/main/kotlin/com/velocidi/Velocidi.kt
@@ -1,5 +1,5 @@
 package com.velocidi
 
-fun main(args : Array<String>) {
+fun main(args: Array<String>) {
     println("Welcome to Velocidi SDK")
 }


### PR DESCRIPTION
This adds [ktlint](https://ktlint.github.io/) (through [ktlint-gradle](https://github.com/JLLeitschuh/ktlint-gradle)) linter and formatter to our gradle tasks. We now have, among others, tasks such as `ktlintFormat` that automatically formats our code according to the plugin defaults.

I reckon we can start with these and improve on them in the future if necessary...

I made `compile*` tasks depend on `ktlintFormat` just to make sure the formatter runs in most situations (not only assemble) to try to avoid situations where the developer pushes unformatted code.